### PR TITLE
Fix: create channel for newly created rooms

### DIFF
--- a/assets/js/components/menu-container.jsx
+++ b/assets/js/components/menu-container.jsx
@@ -93,6 +93,8 @@ class MenuContainer extends React.Component {
 		})
 		.then((response) => {
 			let room = response.room;
+			room.channel = getRoomChannel(room.id);
+			this.listenToNewMessages(room);
 			this.props.addRoom(room);
 		})
 		.catch((err) => {


### PR DESCRIPTION
When creating a new room via the compose button, the room was
added to the Redux store without a Phoenix Channel attached.
This caused a crash when trying to send a message:

`TypeError: undefined is not an object (evaluating 'room.channel.push')`

Now mirrors the same pattern used in `componentDidMount`:
join the channel, listen for incoming messages, then dispatch.