### PR TITLE
fix: move Guardian JWT secret key to environment variable

### DIFF
--- a/.opencode/plans/security-fixes/gh44-unhandled-ecto-error.md
+++ b/.opencode/plans/security-fixes/gh44-unhandled-ecto-error.md
@@ -1,0 +1,76 @@
+# [GH#44] `Repo.get_by!` raises on missing counterpart username
+
+**Severity:** MEDIUM
+**Commit scope:** `lib/messengyr/chat/chat.ex`, `lib/messengyr_web/controllers/api/room_controller.ex`
+
+## Problem
+
+`Chat.create_room_with_counterpart/2` uses `Repo.get_by!`:
+
+```elixir
+def create_room_with_counterpart(me, counterpart_username) do
+  counterpart = Repo.get_by!(User, username: counterpart_username)
+  ...
+end
+```
+
+When the username doesn't exist, `Repo.get_by!` raises `Ecto.NoResultsError`,
+causing a 500 Internal Server Error. This:
+
+- Returns a 500 error instead of a proper 404
+- Leaks stack traces in dev mode
+- Also reveals username existence (valid usernames succeed, invalid ones crash)
+
+## Fix Plan
+
+### Step 1: Replace `Repo.get_by!` in `lib/messengyr/chat/chat.ex`
+
+```elixir
+def create_room_with_counterpart(me, counterpart_username) do
+  case Repo.get_by(User, username: counterpart_username) do
+    nil ->
+      {:error, :user_not_found}
+
+    counterpart ->
+      members = [counterpart, me]
+
+      with {:ok, room} <- create_room() do
+        add_room_users(room, members)
+      end
+  end
+end
+```
+
+### Step 2: Handle the new error tuple in `room_controller.ex`
+
+Replace the `create` action:
+
+```elixir
+def create(conn, %{"counterpartUsername" => counterpart_username}) do
+  user = Guardian.Plug.current_resource(conn)
+
+  case Chat.create_room_with_counterpart(user, counterpart_username) do
+    {:ok, room} ->
+      render(conn, "show.json", %{room: room, me: user})
+
+    {:error, :user_not_found} ->
+      conn
+      |> put_status(:not_found)
+      |> put_view(MessengyrWeb.ErrorView)
+      |> render("error.json", message: "User not found")
+  end
+end
+```
+
+## Verification
+
+1. `mix test` — all tests pass
+2. `POST /api/rooms` with a non-existent `counterpartUsername`:
+   ```bash
+   curl -X POST -H "Authorization: Bearer <jwt>" \
+        -d "counterpartUsername=nobody" \
+        http://localhost:4000/api/rooms
+   ```
+   Returns `404` with `{"error": {"message": "User not found"}}` — no crash.
+
+3. `POST /api/rooms` with an existing username still succeeds.

--- a/.opencode/plans/security-fixes/gh45-missing-message-length-limit.md
+++ b/.opencode/plans/security-fixes/gh45-missing-message-length-limit.md
@@ -1,0 +1,54 @@
+# [GH#45] Message text has no length validation
+
+**Severity:** MEDIUM
+**Commit scope:** `lib/messengyr/chat/message.ex`
+
+## Problem
+
+`Message.changeset/2` only validates that `:text` is present — it does not
+limit its length:
+
+```elixir
+def changeset(message, attrs) do
+  message
+  |> cast(attrs, [:text])
+  |> validate_required([:text])
+end
+```
+
+An attacker can send arbitrarily long messages via the channel's
+`"message:new"` event, causing:
+- Database storage bloat
+- Slow queries when loading rooms with many oversized messages
+- Potential denial of service on the frontend rendering large strings
+
+## Fix Plan
+
+### Step 1: Add `validate_length` to `Message.changeset`
+
+```elixir
+def changeset(message, attrs) do
+  message
+  |> cast(attrs, [:text])
+  |> validate_required([:text])
+  |> validate_length(:text, max: 5000)
+end
+```
+
+5000 characters is generous for a chat message (~1000 words) while
+preventing abuse.
+
+## Verification
+
+1. `mix test` — all tests pass
+2. In `iex -S mix`:
+   ```elixir
+   # Normal message
+   cs = Messengyr.Chat.Message.changeset(%Messengyr.Chat.Message{}, %{text: "Hello"})
+   cs.valid?  # => true
+
+   # Overly long message
+   long = String.duplicate("a", 5001)
+   cs = Messengyr.Chat.Message.changeset(%Messengyr.Chat.Message{}, %{text: long})
+   cs.valid?  # => false
+   ```

--- a/.opencode/plans/security-fixes/gh46-weak-password-minimum.md
+++ b/.opencode/plans/security-fixes/gh46-weak-password-minimum.md
@@ -1,0 +1,36 @@
+# [GH#46] Password minimum length is only 4 characters
+
+**Severity:** MEDIUM
+**Commit scope:** `lib/messengyr/accounts/accounts.ex`
+
+## Problem
+
+`Accounts.register_changeset/1` enforces a 4-character minimum on passwords:
+
+```elixir
+|> validate_length(:password, min: 4)
+```
+
+With only lowercase letters, a 4-char password has ~457k possible values —
+trivially bruteforceable in seconds. Industry standard minimum is 8 characters.
+
+## Fix Plan
+
+### Step 1: Increase minimum length in `accounts.ex`
+
+```diff
+-  |> validate_length(:password, min: 4)
++  |> validate_length(:password, min: 8)
+```
+
+### Step 2: Check existing tests
+
+The test file `test/messengyr/accounts/accounts_test.exs` uses `"pa55w0rd"`
+(8 chars) for valid-data tests and doesn't test the minimum-length boundary,
+so no test changes are needed.
+
+## Verification
+
+1. `mix test` — all tests pass
+2. In the signup form: a 4-char password shows a validation error
+3. In the signup form: an 8+ char password succeeds

--- a/.opencode/plans/security-fixes/gh47-overly-long-session-ttl.md
+++ b/.opencode/plans/security-fixes/gh47-overly-long-session-ttl.md
@@ -1,0 +1,42 @@
+# [GH#47] Session TTL is 30 days
+
+**Severity:** LOW
+**Commit scope:** `config/config.exs`
+
+## Problem
+
+Guardian tokens have a 30-day TTL:
+
+```elixir
+ttl: {30, :days},
+```
+
+If a JWT is stolen (XSS, leaked logs, MITM), the attacker has 30 days of
+uninterrupted access. This app has no token-revocation mechanism (no
+blacklist, no refresh-token rotation).
+
+## Fix Plan
+
+### Step 1: Reduce the TTL
+
+```diff
+-  ttl: {30, :days},
++  ttl: {7, :days},
+```
+
+For a chat app, 7 days is a reasonable balance between user convenience
+and security. Users are logged out after a week of inactivity and must
+re-authenticate.
+
+### If Issue 01 was already applied
+
+Make the same change in each environment file:
+- `config/dev.exs`
+- `config/test.exs`
+- `config/prod.exs`
+
+## Verification
+
+1. `mix test` — all tests pass
+2. Log in, decode the JWT at `jwt.io` — the `exp` claim should be ~7 days
+   from `iat` (down from 30)

--- a/.opencode/plans/security-fixes/gh48-missing-runtime-config.md
+++ b/.opencode/plans/security-fixes/gh48-missing-runtime-config.md
@@ -1,0 +1,55 @@
+# [GH#48] Missing `config/runtime.exs`
+
+**Severity:** LOW
+**Commit scope:** `config/runtime.exs` (new file)
+
+## Problem
+
+The app uses the older `import_config "#{Mix.env()}.exs"` pattern where all
+config is resolved at compile time. Production secrets (`SECRET_KEY_BASE`,
+`GUARDIAN_SECRET_KEY`) are read from env vars in `prod.exs`, but this means:
+
+1. To rotate a secret, you must recompile and redeploy
+2. There is no single file that documents all required runtime env vars
+3. The compiled BEAM files contain the resolved values in memory
+
+The modern Phoenix pattern is `config/runtime.exs` — loaded at application
+start (not compile time), so secrets can be changed without recompiling.
+
+## Fix Plan
+
+### Step 1: Create `config/runtime.exs`
+
+```elixir
+import Config
+
+# Runtime configuration — loaded at application start, not compile time.
+# Use this for secrets that may change between deployments without recompiling.
+
+if config_env() == :prod do
+  config :messengyr, Messengyr.Auth.Guardian,
+    secret_key: System.fetch_env!("GUARDIAN_SECRET_KEY")
+
+  config :messengyr, MessengyrWeb.Endpoint,
+    secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
+end
+```
+
+`System.fetch_env!/1` crashes at startup with a clear error message if the
+variable is missing — better than silently falling back.
+
+### Note
+
+No `mix.exs` change is needed — `mix release` automatically picks up
+`config/runtime.exs` if it exists.
+
+The configs in `prod.exs` can remain as-is; `runtime.exs` overrides them
+at runtime. They serve as documentation of the default/expected values.
+
+## Verification
+
+1. `mix test` — all tests pass
+2. `MIX_ENV=prod mix release` — release builds successfully
+3. Run release with env vars set — app starts normally
+4. Run release without `GUARDIAN_SECRET_KEY` — app fails at startup with
+   `"missing environment variable GUARDIAN_SECRET_KEY"` (clear error)

--- a/.opencode/plans/security-fixes/gh49-missing-rate-limiting.md
+++ b/.opencode/plans/security-fixes/gh49-missing-rate-limiting.md
@@ -1,0 +1,76 @@
+# [GH#49] No rate limiting on login endpoint
+
+**Severity:** LOW
+**Commit scope:** `mix.exs`, `config/config.exs`, `lib/messengyr_web/plugs/rate_limit.ex` (new), `lib/messengyr_web/router.ex`
+
+## Problem
+
+The login endpoint (`POST /login`) has no rate limiting. An attacker can
+brute-force passwords or flood the endpoint with unlimited requests. Even
+with the timing-attack fix (Issue 04), unlimited password attempts are still
+possible.
+
+## Fix Plan
+
+### Step 1: Add `hammer` dependency to `mix.exs`
+
+```elixir
+{:hammer, "~> 6.0"},
+```
+
+### Step 2: Configure Hammer in `config/config.exs`
+
+```elixir
+config :hammer,
+  backend: {Hammer.Backend.ETS, [expiry_ms: 60_000, cleanup_interval_ms: 60_000]}
+```
+
+ETS backend is in-memory — no external dependency needed.
+
+### Step 3: Create `lib/messengyr_web/plugs/rate_limit.ex`
+
+```elixir
+defmodule MessengyrWeb.Plugs.RateLimit do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    ip = conn.remote_ip |> Tuple.to_list() |> Enum.join(".")
+
+    case Hammer.check_rate("login:#{ip}", 60_000, 5) do
+      {:allow, _count} ->
+        conn
+
+      {:deny, _count} ->
+        conn
+        |> put_status(:too_many_requests)
+        |> Phoenix.Controller.put_view(MessengyrWeb.ErrorView)
+        |> Phoenix.Controller.render("error.json", message: "Too many requests. Try again later.")
+        |> halt()
+    end
+  end
+end
+```
+
+Rate limit: **5 requests per 60 seconds per IP**.
+
+### Step 4: Add plug to the browser pipeline in `router.ex`
+
+```elixir
+pipeline :browser do
+  ...
+  plug :put_secure_browser_headers
+  plug MessengyrWeb.Plugs.RateLimit    # ← add before Guardian
+  plug Guardian.Plug.Pipeline, ...
+end
+```
+
+Placing it before Guardian means rate limiting applies before any bcrypt
+work is done — no wasted CPU on throttled requests.
+
+## Verification
+
+1. `mix deps.get && mix test` — all tests pass
+2. Send 6 rapid `POST /login` requests from the same IP — the 6th gets `429`
+3. Wait 60 seconds — rate limit resets, requests work again

--- a/.opencode/plans/security-fixes/gh50-hardcoded-guardian-secret.md
+++ b/.opencode/plans/security-fixes/gh50-hardcoded-guardian-secret.md
@@ -1,0 +1,79 @@
+# [GH#50] Hardcoded Guardian JWT secret key
+
+**Severity:** CRITICAL
+**Commit scope:** `config/config.exs`, `config/dev.exs`, `config/test.exs`, `config/prod.exs`
+
+## Problem
+
+The Guardian JWT signing key is hardcoded in `config/config.exs` as `"5ecret_k3y"` — a
+trivially guessable value. Anyone with repo access can forge valid JWTs for any user
+in dev and test environments. In production, if the `GUARDIAN_SECRET_KEY` env var is
+ever missing (e.g., misconfigured deployment), the app silently falls back to this
+weak key instead of failing to start.
+
+Additionally, `allowoed_drift` is misspelled in the same config block — Guardian silently
+ignores it, so JWT clock-drift tolerance is effectively 0 ms. This fix corrects the
+spelling to `allowed_drift`.
+
+## Fix Plan
+
+### Step 1: Remove Guardian config from `config/config.exs`
+
+Delete lines 40–44 (the entire Guardian config block):
+
+```diff
+- config :messengyr, Messengyr.Auth.Guardian,
+-   issuer: "messengyr",
+-   ttl: {30, :days},
+-   allowoed_drift: 2000,
+-   secret_key: "5ecret_k3y"
+```
+
+### Step 2: Add Guardian config to `config/dev.exs`
+
+Append at end of file:
+
+```elixir
+config :messengyr, Messengyr.Auth.Guardian,
+  issuer: "messengyr",
+  ttl: {30, :days},
+  allowed_drift: 2000,
+  secret_key:
+    System.get_env("GUARDIAN_SECRET_KEY") || "dev-only-insecure-key-do-not-use-in-prod"
+```
+
+### Step 3: Add Guardian config to `config/test.exs`
+
+Append at end of file:
+
+```elixir
+config :messengyr, Messengyr.Auth.Guardian,
+  issuer: "messengyr",
+  ttl: {30, :days},
+  allowed_drift: 2000,
+  secret_key:
+    System.get_env("GUARDIAN_SECRET_KEY") || "dev-only-insecure-key-do-not-use-in-prod"
+```
+
+### Step 4: Expand Guardian config in `config/prod.exs`
+
+Replace the single-line config (line 29) with the full block:
+
+```diff
+- config :messengyr, Messengyr.Auth.Guardian, secret_key: System.get_env("GUARDIAN_SECRET_KEY")
++ config :messengyr, Messengyr.Auth.Guardian,
++   issuer: "messengyr",
++   ttl: {30, :days},
++   allowed_drift: 2000,
++   secret_key: System.get_env("GUARDIAN_SECRET_KEY")
+```
+
+The fallback strings in dev/test (`"dev-only-insecure-key-do-not-use-in-prod"`) are
+intentionally different from the old hardcoded value to make it obvious if one leaks.
+
+## Verification
+
+1. `mix test` — all existing tests pass
+2. `mix phx.server` — app starts and login flow works
+3. Unset `GUARDIAN_SECRET_KEY` in dev — app still works using the dev fallback
+4. Confirm `GUARDIAN_SECRET_KEY` is never printed in logs or error pages

--- a/.opencode/plans/security-fixes/gh51-hardcoded-secret-key-base.md
+++ b/.opencode/plans/security-fixes/gh51-hardcoded-secret-key-base.md
@@ -1,0 +1,61 @@
+# [GH#51] Hardcoded `secret_key_base`
+
+**Severity:** CRITICAL
+**Commit scope:** `config/config.exs`, `config/dev.exs`, `config/test.exs`
+
+## Problem
+
+The Phoenix `secret_key_base` is hardcoded in `config/config.exs`:
+
+```elixir
+secret_key_base: "qWetP8ZBUJH0KWGM8Zqy9Ev48Nqi9i1RfH0fMknMLtxGCyQAjwKei7r+TO+QpuJ7",
+```
+
+This key signs session cookies and CSRF tokens. Anyone with repo access can:
+- Forge valid session cookies
+- Bypass CSRF protection
+- Decrypt signed session data
+
+Production overrides this via `SECRET_KEY_BASE` env var, but dev and test
+environments use the fixed value from source control.
+
+## Fix Plan
+
+### Step 1: Change `config/config.exs` to read from env var
+
+```diff
+-  secret_key_base: "qWetP8ZBUJH0KWGM8Zqy9Ev48Nqi9i1RfH0fMknMLtxGCyQAjwKei7r+TO+QpuJ7",
++  secret_key_base: System.get_env("SECRET_KEY_BASE"),
+```
+
+### Step 2: Add dev fallback in `config/dev.exs`
+
+```elixir
+config :messengyr, MessengyrWeb.Endpoint,
+  secret_key_base:
+    System.get_env("SECRET_KEY_BASE") || "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+```
+
+### Step 3: Add test fallback in `config/test.exs`
+
+```elixir
+config :messengyr, MessengyrWeb.Endpoint,
+  secret_key_base:
+    System.get_env("SECRET_KEY_BASE") || "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+```
+
+### Step 4: Confirm `config/prod.exs` is unchanged
+
+It already reads from env var:
+
+```elixir
+secret_key_base: System.get_env("SECRET_KEY_BASE")
+```
+
+No change needed.
+
+## Verification
+
+1. `mix test` — all tests pass
+2. `mix phx.server` — app boots, login/session flow works
+3. `curl -v http://localhost:4000/` — returns 200, cookies set correctly

--- a/.opencode/plans/security-fixes/gh52-unauthenticated-user-api.md
+++ b/.opencode/plans/security-fixes/gh52-unauthenticated-user-api.md
@@ -1,0 +1,67 @@
+# [GH#52] Unauthenticated `GET /api/user/:id`
+
+**Severity:** HIGH
+**Commit scope:** `lib/messengyr_web/controllers/api/user_controller.ex`
+
+## Problem
+
+`UserController` has no authentication check. The `:api` pipeline uses
+`Guardian.Plug.LoadResource, allow_blank: true` which does **not** reject
+unauthenticated requests — it just leaves `current_resource` as `nil` and
+continues. Since `UserController` never calls `EnsureAuthenticated`, any
+client can enumerate all users by ID:
+
+```bash
+curl http://localhost:4000/api/user/1   # returns user data (no token needed)
+curl http://localhost:4000/api/user/2   # returns user data
+```
+
+Compare with `RoomController` which uses the correct pattern:
+
+```elixir
+plug Guardian.Plug.EnsureAuthenticated, error_handler: __MODULE__
+```
+
+## Fix Plan
+
+### Step 1: Add auth plug to `UserController`
+
+Replace the full file content with:
+
+```elixir
+defmodule MessengyrWeb.UserController do
+  use MessengyrWeb, :controller
+  alias Messengyr.Accounts
+  alias MessengyrWeb.ErrorView
+
+  plug Guardian.Plug.EnsureAuthenticated, error_handler: __MODULE__
+
+  def auth_error(conn, {_type, _reason}, _opts) do
+    conn
+    |> put_status(401)
+    |> put_view(ErrorView)
+    |> render("error.json", message: "You are not authenticated.")
+  end
+
+  action_fallback MessengyrWeb.FallbackController
+
+  def show(conn, %{"id" => user_id}) do
+    user = user_id |> Accounts.get_user()
+
+    if user do
+      conn |> render("show.json", user: user)
+    end
+  end
+end
+```
+
+Three additions:
+1. `alias MessengyrWeb.ErrorView`
+2. `plug Guardian.Plug.EnsureAuthenticated, error_handler: __MODULE__`
+3. `auth_error/3` returning 401 JSON
+
+## Verification
+
+1. `mix test` — all tests pass
+2. Without token — `curl -v http://localhost:4000/api/user/1` returns `401`
+3. With valid Bearer token — `curl -v -H "Authorization: Bearer <jwt>" http://localhost:4000/api/user/1` returns `200`

--- a/.opencode/plans/security-fixes/gh53-login-timing-attack.md
+++ b/.opencode/plans/security-fixes/gh53-login-timing-attack.md
@@ -1,0 +1,82 @@
+# [GH#53] Timing attack in login authentication
+
+**Severity:** HIGH
+**Commit scope:** `lib/messengyr/accounts/session.ex`
+
+## Problem
+
+`Session.check_password/2` returns immediately when a username doesn't exist
+(no bcrypt call), but takes ~ms when it does (bcrypt verification). This lets
+attackers enumerate valid usernames by measuring response times:
+
+```elixir
+defp check_password(nil, _given_password) do
+  {:error, "No user with this username was found!"}  # ← instant return
+end
+
+defp check_password(%{encrypted_password: pw} = user, given_password) do
+  case Bcrypt.verify_pass(given_password, pw) do      # ← ~ms delay
+    true -> {:ok, user}
+    _ -> {:error, "Incorrect password"}
+  end
+end
+```
+
+Additionally, the error messages themselves reveal whether the username exists:
+"No user with this username was found!" vs "Incorrect password".
+
+## Fix Plan
+
+### Step 1: Replace `lib/messengyr/accounts/session.ex`
+
+```elixir
+defmodule Messengyr.Accounts.Session do
+  alias Messengyr.Accounts.User
+  alias Messengyr.Repo
+
+  def authenticate(%{"username" => username, "password" => given_password}) do
+    user = Repo.get_by(User, username: username)
+    check_password(user, given_password)
+  end
+
+  defp check_password(nil, given_password) do
+    Bcrypt.no_user_verify()
+    {:error, "Invalid username or password"}
+  end
+
+  defp check_password(%{encrypted_password: encrypted_password} = user, given_password) do
+    case Bcrypt.verify_pass(given_password, encrypted_password) do
+      true -> {:ok, user}
+      _ -> {:error, "Invalid username or password"}
+    end
+  end
+end
+```
+
+Two changes:
+1. `Bcrypt.no_user_verify()` added — runs a dummy bcrypt verification that takes
+   the same amount of time as a real one (prevents timing side-channel)
+2. Error messages unified to `"Invalid username or password"` — attacker cannot
+   distinguish "wrong password" from "no such user"
+
+`Bcrypt.no_user_verify/0` is part of `bcrypt_elixir ~> 3.3` (already a dependency).
+
+## Verification
+
+1. `mix test` — existing `AccountsTest` still passes
+2. In `iex -S mix`:
+   ```elixir
+   # Non-existent user — same error as wrong password
+   Session.authenticate(%{"username" => "nobody", "password" => "x"})
+   # => {:error, "Invalid username or password"}
+
+   # Wrong password for existing user — same error
+   Session.authenticate(%{"username" => "mingyar", "password" => "wrong"})
+   # => {:error, "Invalid username or password"}
+
+   # Valid login still works
+   Session.authenticate(%{"username" => "mingyar", "password" => "pa55w0rd"})
+   # => {:ok, %User{}}
+   ```
+3. Login form on the site: wrong credentials show "Invalid username or password"
+   flash message regardless of whether the username exists.

--- a/.opencode/plans/security-fixes/gh54-unquoted-img-src.md
+++ b/.opencode/plans/security-fixes/gh54-unquoted-img-src.md
@@ -1,0 +1,37 @@
+# [GH#54] Unquoted `<img src>` in layout template
+
+**Severity:** HIGH
+**Commit scope:** `lib/messengyr_web/templates/layout/header.html.eex`
+
+## Problem
+
+The avatar `<img>` tag in the header template has an unquoted `src` attribute:
+
+```eex
+<img src=<%= avatar(@conn) %> />
+```
+
+HTML allows omitting quotes around attribute values only if the value contains
+no spaces or special characters. If the `avatar/1` function ever returns a value
+with spaces (e.g., a URL with query parameters, or if the email hash format
+changes), the browser interprets the space as an attribute separator. This is
+an HTML injection vector.
+
+Currently `avatar/1` returns `"http://www.gravatar.com/avatar/<hex>"` which
+happens to have no spaces, but relying on that is fragile and violates
+defense-in-depth.
+
+## Fix Plan
+
+### Step 1: Add quotes to `src` attribute in `header.html.eex`
+
+```diff
+- <img src=<%= avatar(@conn) %> />
++ <img src="<%= avatar(@conn) %>" />
+```
+
+## Verification
+
+1. `mix test` — all tests pass
+2. Load any page in the browser — avatar image displays correctly
+3. View page source — `<img>` tag has properly quoted `src=""`

--- a/.opencode/plans/security-fixes/gh55-guardian-typo-allowed-drift.md
+++ b/.opencode/plans/security-fixes/gh55-guardian-typo-allowed-drift.md
@@ -1,0 +1,39 @@
+# [GH#55] Guardian typo: `allowoed_drift` → `allowed_drift`
+
+**Severity:** HIGH
+**Commit scope:** `config/config.exs`
+
+## Problem
+
+The Guardian config in `config/config.exs` has a typo:
+
+```elixir
+allowoed_drift: 2000,
+```
+
+The correct key is `allowed_drift` (double 'l'). Guardian silently ignores
+unknown config keys, so the clock drift tolerance is effectively 0 ms. This
+causes intermittent authentication failures when the server clock and the
+token-issuer clock are slightly out of sync.
+
+## Fix Plan
+
+### Step 1: Fix the typo in `config/config.exs`
+
+```diff
+-   allowoed_drift: 2000,
++   allowed_drift: 2000,
+```
+
+### Important note
+
+If you have already applied **Issue 01** (which moves Guardian config to
+env-specific files), this typo is already fixed as part of that change.
+In that case, skip this commit.
+
+## Verification
+
+1. `mix test` — all tests pass
+2. No visible behaviour change — the 2000 ms drift tolerance now actually applies
+3. If you previously saw intermittent "token expired" errors in test/dev, they
+   should now be resolved

--- a/.opencode/plans/security-fixes/gh56-insecure-gravatar-url.md
+++ b/.opencode/plans/security-fixes/gh56-insecure-gravatar-url.md
@@ -1,0 +1,47 @@
+# [GH#56] Gravatar URL uses HTTP instead of HTTPS
+
+**Severity:** MEDIUM
+**Commit scope:** `lib/messengyr_web/views/layout_view.ex`, `lib/messengyr_web/views/api/user_view.ex`
+
+## Problem
+
+Two files construct Gravatar avatar URLs using `http://`:
+
+- `lib/messengyr_web/views/layout_view.ex` line 22
+- `lib/messengyr_web/views/api/user_view.ex` line 35
+
+```elixir
+"http://www.gravatar.com/avatar/#{hash_email}"
+```
+
+The production site runs on HTTPS (`messengyr-app.herokuapp.com`). Loading
+avatar images over HTTP triggers browser mixed-content warnings and may
+block the images entirely depending on browser settings.
+
+## Fix Plan
+
+### Step 1: Fix `lib/messengyr_web/views/layout_view.ex`
+
+```diff
+-    "http://www.gravatar.com/avatar/#{hash_email}"
++    "https://www.gravatar.com/avatar/#{hash_email}"
+```
+
+### Step 2: Fix `lib/messengyr_web/views/api/user_view.ex`
+
+Two occurrences — the code (line 35) and the doctest example (line 21):
+
+```diff
+-    avatar_url = "http://www.gravatar.com/avatar/#{hash_email}"
++    avatar_url = "https://www.gravatar.com/avatar/#{hash_email}"
+```
+
+```diff
+-    avatarURL: "http://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0",
++    avatarURL: "https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0",
+```
+
+## Verification
+
+1. `mix test` — `UserViewTest` runs doctests and should still pass
+2. `mix phx.server` — load the app, check browser console for no mixed-content errors

--- a/.opencode/plans/security-fixes/gh57-room-join-info-leak.md
+++ b/.opencode/plans/security-fixes/gh57-room-join-info-leak.md
@@ -1,0 +1,56 @@
+# [GH#57] Room channel join errors leak room existence
+
+**Severity:** MEDIUM
+**Commit scope:** `lib/messengyr_web/channels/room_channel.ex`
+
+## Problem
+
+`RoomChannel.join/3` returns different error messages depending on the reason
+for failure:
+
+```elixir
+# Room exists but user is not a member:
+{:error, %{reason: "You're not a member of this room!"}}
+
+# Room does not exist:
+{:error, %{reason: "This room doesn't exist!"}}
+```
+
+An attacker can probe room IDs via WebSocket and distinguish between "room
+exists" and "room does not exist" based on the error message. This information
+disclosure helps attackers map the application's data.
+
+## Fix Plan
+
+### Step 1: Replace `join/3` in `room_channel.ex`
+
+```elixir
+@impl true
+def join("room:" <> room_id, _payload, socket) do
+  me = socket.assigns.current_user
+
+  case Chat.get_room(room_id) do
+    %Room{} = room ->
+      if Chat.room_has_user?(room, me) do
+        {:ok, socket}
+      else
+        {:error, %{reason: "Room not found"}}
+      end
+
+    _ ->
+      {:error, %{reason: "Room not found"}}
+  end
+end
+```
+
+Both error paths now return the exact same message — `"Room not found"`.
+The attacker gets zero information about whether the room exists.
+
+## Verification
+
+1. `mix test` — all tests pass
+2. Open chat app in browser — joining owned rooms still works
+3. Via WebSocket console: joining a non-existent room returns
+   `{"reason": "Room not found"}`
+4. Via WebSocket console: joining a room you don't belong to returns the
+   same `{"reason": "Room not found"}` — indistinguishable

--- a/.opencode/plans/security-fixes/gh58-swap-guardian-for-joken.md
+++ b/.opencode/plans/security-fixes/gh58-swap-guardian-for-joken.md
@@ -1,0 +1,128 @@
+# [GH#58] Swap Guardian for Joken
+
+**Severity:** LOW (improvement, not vulnerability)
+**Depends on:** All priority-critical and priority-high fixes first (GH#50–GH#55)
+
+## Context
+
+Guardian 2.x is in maintenance mode and over-engineered for this app's needs.
+It requires 3 modules (`Guardian`, `Pipeline`, `ApiPipeline`) + config in 4 files
++ 6 plug call patterns spread across controllers, views, socket, and router.
+
+Joken does the same job in ~15 lines of code with no pipeline plumbing.
+
+## Scope
+
+**11 files** need changes, **3 files** can be deleted, **1 new file** created.
+
+### Files to DELETE (3)
+
+| File | Reason |
+|------|--------|
+| `lib/messengyr/auth/guardian.ex` | Replaced by Joken helper module |
+| `lib/messengyr/auth/pipeline.ex` | No more Guardian.Plug.Pipeline |
+| `lib/messengyr/auth/api_pipeline.ex` | No more Guardian.Plug.Pipeline |
+
+### Files to CREATE (1)
+
+| File | Purpose |
+|------|---------|
+| `lib/messengyr/auth/joken.ex` | `sign/1`, `verify/1`, `load_user/1` — the entire auth interface |
+
+### Files to MODIFY (8)
+
+| File | What changes |
+|------|-------------|
+| `config/config.exs` | Remove Guardian config (already done in GH#50) |
+| `config/dev.exs` | Replace Guardian config with Joken config |
+| `config/test.exs` | Same |
+| `config/prod.exs` | Same |
+| `lib/messengyr_web/router.ex` | Remove Guardian pipeline plugs, add custom session auth plug |
+| `lib/messengyr_web/controllers/page_controller.ex` | Replace `Guardian.Plug.sign_in/2` → `Auth.Joken.sign/1`, `sign_out` → `clear_session` |
+| `lib/messengyr_web/channels/user_socket.ex` | Replace `Guardian.decode_and_verify/1` → `Auth.Joken.verify/1` |
+| `lib/messengyr_web/views/chat_view.ex` | Replace `Guardian.Plug.current_token/1` → read JWT from session |
+| `lib/messengyr_web/views/layout_view.ex` | Replace `Guardian.Plug.authenticated?/2` + `current_resource/1` with session checks |
+| `lib/messengyr_web/controllers/api/room_controller.ex` | Replace `Guardian.Plug.EnsureAuthenticated` + `current_resource/1` with custom plug |
+| `lib/messengyr_web/controllers/api/message_controller.ex` | Replace `Guardian.Plug.current_resource(conn)` with custom plug |
+| `lib/messengyr_web/controllers/chat_controller.ex` | Replace `Guardian.Plug.EnsureAuthenticated` with custom plug |
+
+## Design
+
+### New Auth module (`lib/messengyr/auth/joken.ex`)
+
+```elixir
+defmodule Messengyr.Auth.Token do
+  # Sign a user → return JWT
+  def sign(user), do: ...
+
+  # Verify JWT → return user
+  def verify(jwt), do: ...
+end
+```
+
+Two functions. No pipelines, no plugs config, no error handlers.
+Controllers use a simple `plug :authenticate` function plug.
+
+### New session management
+
+Instead of Guardian's cookie pipeline:
+- On login: generate JWT, store in session and return to client
+- On logout: clear session
+- Browser: use `get_session(conn, :jwt)` to read
+- API: use `Authorization: Bearer <jwt>` header
+- `MessengyrWeb.Plugs.Authenticate` — reads JWT from session or header, loads user into `conn.assigns.current_user`
+
+### Delete the pipeline modules
+
+`guardian.ex`, `pipeline.ex`, `api_pipeline.ex` — all gone.
+The router goes from:
+```elixir
+pipeline :browser do
+  plug Guardian.Plug.Pipeline, ...
+end
+pipeline :browser_session do
+  plug Messengyr.Auth.Pipeline
+end
+```
+To:
+```elixir
+pipeline :auth do
+  plug MessengyrWeb.Plugs.Authenticate
+end
+```
+
+## Prerequisites
+
+All of these must be fixed **before** this swap:
+
+- [ ] GH#50 — Hardcoded Guardian secret (done)
+- [ ] GH#51 — Hardcoded secret_key_base
+- [ ] GH#52 — Unauthenticated user API
+- [ ] GH#53 — Timing attack in login
+- [ ] GH#54 — Unquoted img src
+- [ ] GH#55 — Guardian allowed_drift typo
+- [ ] GH#44 — Repo.get_by! raises on missing user
+- [ ] Full test coverage for auth flows (no tests currently exist for login/logout/token verification)
+
+## Migration strategy
+
+One single commit. The app will be broken mid-swap, so this must be done atomically:
+
+1. Add `joken` to `mix.exs`
+2. Create `lib/messengyr/auth/token.ex`
+3. Create `lib/messengyr_web/plugs/authenticate.ex`
+4. Update `router.ex`
+5. Update all controllers, views, socket
+6. Delete old pipeline modules
+7. Remove Guardian from `mix.exs`
+8. Update config files
+9. `mix test` — must be green
+
+## Verification
+
+1. `mix test` — all tests pass
+2. Login → get redirected to `/messages` with session
+3. API: `POST /api/rooms` with Bearer token works
+4. WebSocket connects with `guardianToken` param
+5. Logout clears session
+6. Unauthenticated requests get 401/redirect

--- a/.opencode/skills/learn-from-fix/MEMORY.md
+++ b/.opencode/skills/learn-from-fix/MEMORY.md
@@ -1,5 +1,22 @@
 # Lessons Learned
 
+## Workflow: Test-First Security Fix Process
+
+### Lesson: Write a failing test first, show it, then implement the fix
+- **Pattern**: When fixing a security issue (or any bug), ALWAYS write a test that captures the problem first. Show the failing test to the user. Only after they confirm, implement the fix. Never jump straight to code.
+- **Why**: This guarantees:
+  1. The fix actually addresses the specific vulnerability (test proves it was broken)
+  2. The test prevents regression (test proves it's now fixed)
+  3. The user reviews the test expectations before any code changes
+- **Fix**: Workflow is:
+  1. Write the failing test (that demonstrates the vulnerability)
+  2. Run it to confirm it fails
+  3. Show the user the test output
+  4. Wait for approval
+  5. Implement the fix
+  6. Run the test again — it passes
+  7. Run full `mix test` — nothing else broke
+
 ## Deployment: Fly.io + Neon (IPv4 DB on IPv6-only infra)
 
 ### Lesson 1: DNS64 is NOT available on Fly.io — use `getent` for IPv4 resolution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ Facebook Messenger clone. **Phoenix 1.5.7** + **Phoenix Channels** + **React 16 
 
 ### Branch workflow (MANDATORY — never bypass)
 
+0. **Always pull the latest `main` first.** Before starting work on any issue, fetch and pull the most recent copy of `main`:
+   ```bash
+   git checkout main && git pull origin main
+   ```
 1. **Create a feature branch first.** Never commit directly to `main`. Branch name convention: `fix/description` or `feat/description`.
 2. **Implement on the branch.** All work happens there.
 3. **Ask before every action** — each step requires explicit confirmation:
@@ -18,6 +22,20 @@ Facebook Messenger clone. **Phoenix 1.5.7** + **Phoenix Channels** + **React 16 
    - "Can I open a pull request?" → wait for answer before running `gh pr create`
 4. **When opening a PR, assign the user as reviewer.** Use: `gh pr create --assignee @me` or assign the user specifically.
 5. **After PR is merged, delete the remote branch.**
+
+### Security fix workflow (MANDATORY)
+
+When fixing a security issue (or any bug), follow this process:
+
+1. **Write a failing test first** — write a test that captures the vulnerability
+2. **Run it to confirm** — it must fail, proving the bug exists
+3. **Show the user** the failing test output
+4. **Wait for user approval** before writing any fix code
+5. **Implement the fix**
+6. **The test now passes** — the vulnerability is closed
+7. **Run `mix test`** — full suite is green, nothing regressed
+
+Never skip step 1-4. Never jump to fix code before the user has seen the failing test.
 
 ### Never
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -36,9 +36,3 @@ config :phoenix, :json_library, Jason
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"
-
-config :messengyr, Messengyr.Auth.Guardian,
-  issuer: "messengyr",
-  ttl: {30, :days},
-  allowoed_drift: 2000,
-  secret_key: "5ecret_k3y"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -74,3 +74,9 @@ config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
+
+config :messengyr, Messengyr.Auth.Guardian,
+  issuer: "messengyr",
+  ttl: {30, :days},
+  allowed_drift: 2000,
+  secret_key: System.get_env("GUARDIAN_SECRET_KEY") || "dev-only-insecure-key-do-not-use-in-prod"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -26,7 +26,11 @@ config :messengyr, Messengyr.Repo,
   pool_size: 2,
   ssl: true
 
-config :messengyr, Messengyr.Auth.Guardian, secret_key: System.get_env("GUARDIAN_SECRET_KEY")
+config :messengyr, Messengyr.Auth.Guardian,
+  issuer: "messengyr",
+  ttl: {30, :days},
+  allowed_drift: 2000,
+  secret_key: System.get_env("GUARDIAN_SECRET_KEY")
 
 config :phoenix, :serve_endpoints, true
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,3 +20,9 @@ config :messengyr, MessengyrWeb.Endpoint,
 
 # Print only warnings and errors during test
 config :logger, level: :warning
+
+config :messengyr, Messengyr.Auth.Guardian,
+  issuer: "messengyr",
+  ttl: {30, :days},
+  allowed_drift: 2000,
+  secret_key: System.get_env("GUARDIAN_SECRET_KEY") || "dev-only-insecure-key-do-not-use-in-prod"

--- a/test/messengyr/guardian_config_test.exs
+++ b/test/messengyr/guardian_config_test.exs
@@ -1,0 +1,11 @@
+defmodule Messengyr.GuardianConfigTest do
+  use ExUnit.Case, async: true
+
+  test "Guardian secret key is not the hardcoded weak default" do
+    secret_key = Application.get_env(:messengyr, Messengyr.Auth.Guardian, [])[:secret_key]
+
+    refute secret_key == "5ecret_k3y",
+           "Guardian secret key must not be the well-known weak value '5ecret_k3y'. " <>
+             "Set GUARDIAN_SECRET_KEY env var or use a secure dev fallback."
+  end
+end


### PR DESCRIPTION
Closes #50

- Remove hardcoded Guardian JWT secret key from config
- Each environment now reads GUARDIAN_SECRET_KEY from env var
- Dev/test fall back to explicit insecure key (not the old '5ecret_k3y')
- Fix allowed_drift typo (was allowoed_drift)
- Add test asserting secret is not the weak default