### PR TITLE
fix: replace hardcoded secret_key_base with env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Facebook Messenger clone. **Phoenix 1.5.7** + **Phoenix Channels** + **React 16 
 1. **Create a feature branch first.** Never commit directly to `main`. Branch name convention: `fix/description` or `feat/description`.
 2. **Implement on the branch.** All work happens there.
 3. **Ask before every action** — each step requires explicit confirmation:
-   - "Can I commit?" → wait for answer before running `git commit`
+   - "Can I commit?" → wait for answer before running `git commit`. If there's a `.md` file (AGENTS.md, plan files, etc.) among staged changes, ask if the user wants it in a **separate commit** within the same branch.
    - "Can I push?" → wait for answer before running `git push`
    - "Can I open a pull request?" → wait for answer before running `gh pr create`
 4. **When opening a PR, assign the user as reviewer.** Use: `gh pr create --assignee @me` or assign the user specifically.
@@ -42,12 +42,14 @@ When fixing a security issue (or any bug), follow this process:
 5. **Implement the fix**
 6. **The test now passes** — the vulnerability is closed
 7. **Run `mix test`** — full suite is green, nothing regressed
+8. **Wait for user approval before committing** — show the passing test + full suite, then ask "Can I commit?"
 
-Never skip step 1-4. Never jump to fix code before the user has seen the failing test.
+Never skip step 1-4. Never jump to fix code before the user has seen the failing test. Never commit the solution before the user has checked the passing result.
 
 ### Never
 
 - ❌ Commit directly to `main`
+- ❌ Commit solution before user checks the passing result (step 8 in security fix workflow)
 - ❌ Push without asking
 - ❌ Open a PR without asking
 - ❌ Merge your own PR

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,7 @@ config :messengyr,
 # Configures the endpoint
 config :messengyr, MessengyrWeb.Endpoint,
   url: [host: "localhost"],
-  secret_key_base: "qWetP8ZBUJH0KWGM8Zqy9Ev48Nqi9i1RfH0fMknMLtxGCyQAjwKei7r+TO+QpuJ7",
+  secret_key_base: System.get_env("SECRET_KEY_BASE"),
   render_errors: [view: MessengyrWeb.ErrorView, accepts: ~w(html json), layout: false],
   pubsub_server: Messengyr.PubSub,
   session: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,6 +16,9 @@ config :messengyr, Messengyr.Repo,
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :messengyr, MessengyrWeb.Endpoint,
+  secret_key_base:
+    System.get_env("SECRET_KEY_BASE") ||
+      "dev-only-insecure-secret-key-base-must-set-SECRET_KEY_BASE-env-var",
   http: [port: 4000],
   debug_errors: true,
   code_reloader: true,

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,6 +15,9 @@ config :messengyr, Messengyr.Repo,
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :messengyr, MessengyrWeb.Endpoint,
+  secret_key_base:
+    System.get_env("SECRET_KEY_BASE") ||
+      "test-only-insecure-secret-key-base-must-set-SECRET_KEY_BASE-env-var",
   http: [port: 4002],
   server: false
 

--- a/test/messengyr/endpoint_config_test.exs
+++ b/test/messengyr/endpoint_config_test.exs
@@ -1,0 +1,13 @@
+defmodule Messengyr.EndpointConfigTest do
+  use ExUnit.Case, async: true
+
+  test "secret_key_base is not the hardcoded default" do
+    secret_key_base =
+      Application.get_env(:messengyr, MessengyrWeb.Endpoint, [])[:secret_key_base]
+
+    refute secret_key_base ==
+             "qWetP8ZBUJH0KWGM8Zqy9Ev48Nqi9i1RfH0fMknMLtxGCyQAjwKei7r+TO+QpuJ7",
+           "secret_key_base must not be the well-known hardcoded value. " <>
+             "Set SECRET_KEY_BASE env var or use a secure dev/test fallback."
+  end
+end


### PR DESCRIPTION
Closes #51

- Replaces hardcoded secret_key_base in config/config.exs with `System.get_env("SECRET_KEY_BASE")`
- Adds descriptive dev/test fallback strings (>= 64 bytes)
- Adds test asserting secret_key_base is not the old hardcoded value